### PR TITLE
✨ feat(ui): add h/l navigation in fullscreen mode

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -313,12 +313,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.matchKey(msg.String(), m.globalConfig.KeyBindings.NavigateLeft) {
 					if m.activePanel > CollectionsPanel {
 						m.activePanel--
+						// Update fullscreen panel if in fullscreen mode
+						if m.isFullscreen {
+							m.fullscreenPanel = m.activePanel
+						}
 					}
 					return m, nil
 				}
 				if m.matchKey(msg.String(), m.globalConfig.KeyBindings.NavigateRight) {
 					if m.activePanel < ResponsePanel {
 						m.activePanel++
+						// Update fullscreen panel if in fullscreen mode
+						if m.isFullscreen {
+							m.fullscreenPanel = m.activePanel
+						}
 					}
 					return m, nil
 				}
@@ -331,12 +339,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.matchKey(msg.String(), m.globalConfig.KeyBindings.NavigateLeft) {
 					if m.activePanel > CollectionsPanel {
 						m.activePanel--
+						// Update fullscreen panel if in fullscreen mode
+						if m.isFullscreen {
+							m.fullscreenPanel = m.activePanel
+						}
 					}
 					return m, nil
 				}
 				if m.matchKey(msg.String(), m.globalConfig.KeyBindings.NavigateRight) {
 					if m.activePanel < ResponsePanel {
 						m.activePanel++
+						// Update fullscreen panel if in fullscreen mode
+						if m.isFullscreen {
+							m.fullscreenPanel = m.activePanel
+						}
 					}
 					return m, nil
 				}


### PR DESCRIPTION
## Description
Permet de naviguer entre les panels avec h/l tout en restant en mode fullscreen.

## Related Issue
Amélioration de #8

## Changes Made
- Mise à jour des handlers h/l en NORMAL mode pour synchroniser `fullscreenPanel`
- Mise à jour des handlers h/l en VIEW mode pour synchroniser `fullscreenPanel`

## Behavior
```
[FULLSCREEN: Request] → h → [FULLSCREEN: Collections]
[FULLSCREEN: Request] → l → [FULLSCREEN: Response]
```

## Checklist
- [x] Build passes
- [x] Navigation fonctionne en fullscreen