### PR TITLE
feat(runner): add collection runner for batch request execution ✨

### DIFF
--- a/internal/api/runner.go
+++ b/internal/api/runner.go
@@ -1,0 +1,533 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ============================================================================
+// ENUMS
+// ============================================================================
+
+// RunStatus represents the current state of a collection run.
+type RunStatus string
+
+const (
+	RunStatusPending   RunStatus = "pending"   // Created but not started
+	RunStatusRunning   RunStatus = "running"   // Actively executing requests
+	RunStatusCompleted RunStatus = "completed" // All requests executed
+	RunStatusCancelled RunStatus = "canceled"  // User canceled mid-run
+	RunStatusStopped   RunStatus = "stopped"   // Halted due to failure
+)
+
+// String returns the display name for the status.
+func (s RunStatus) String() string {
+	return string(s)
+}
+
+// ResultStatus represents the outcome of a single request execution.
+type ResultStatus string
+
+const (
+	ResultStatusPending ResultStatus = "pending" // Not yet executed
+	ResultStatusRunning ResultStatus = "running" // Currently executing
+	ResultStatusPassed  ResultStatus = "passed"  // All assertions passed
+	ResultStatusFailed  ResultStatus = "failed"  // Some assertions failed
+	ResultStatusError   ResultStatus = "error"   // HTTP or script error
+	ResultStatusSkipped ResultStatus = "skipped" // Not executed (canceled/stopped)
+)
+
+// String returns the display name for the status.
+func (s ResultStatus) String() string {
+	return string(s)
+}
+
+// ============================================================================
+// ERRORS
+// ============================================================================
+
+var (
+	ErrInvalidDelay         = errors.New("delay must be between 0 and 10000 ms")
+	ErrInvalidTimeout       = errors.New("timeout must be positive")
+	ErrInvalidScriptTimeout = errors.New("script timeout must be positive")
+	ErrNoRequests           = errors.New("no requests to run")
+	ErrRunnerBusy           = errors.New("runner is already executing")
+	ErrNoActiveRun          = errors.New("no active run")
+)
+
+// ============================================================================
+// CONFIGURATION
+// ============================================================================
+
+// RunConfig holds configuration settings for a collection run.
+type RunConfig struct {
+	// StopOnFailure halts execution when an assertion fails or HTTP error occurs.
+	StopOnFailure bool `json:"stopOnFailure"`
+
+	// DelayMs is the delay in milliseconds between requests (0-10000).
+	DelayMs int `json:"delayMs"`
+
+	// Timeout is the HTTP request timeout.
+	Timeout time.Duration `json:"-"`
+
+	// ScriptTimeout is the JavaScript execution timeout.
+	ScriptTimeout time.Duration `json:"-"`
+}
+
+// DefaultRunConfig returns the default configuration.
+func DefaultRunConfig() RunConfig {
+	return RunConfig{
+		StopOnFailure: false,
+		DelayMs:       0,
+		Timeout:       30 * time.Second,
+		ScriptTimeout: 5 * time.Second,
+	}
+}
+
+// Validate checks if the configuration is valid.
+func (c *RunConfig) Validate() error {
+	if c.DelayMs < 0 || c.DelayMs > 10000 {
+		return ErrInvalidDelay
+	}
+	if c.Timeout <= 0 {
+		return ErrInvalidTimeout
+	}
+	if c.ScriptTimeout <= 0 {
+		return ErrInvalidScriptTimeout
+	}
+	return nil
+}
+
+// ============================================================================
+// REQUEST INFO & RESPONSE INFO
+// ============================================================================
+
+// RunnerRequestInfo contains metadata about the executed request.
+type RunnerRequestInfo struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Method      string `json:"method"`
+	URL         string `json:"url"`
+	ResolvedURL string `json:"resolvedUrl"`
+}
+
+// RunnerResponseInfo contains HTTP response data.
+type RunnerResponseInfo struct {
+	Status     int               `json:"status"`
+	StatusText string            `json:"statusText"`
+	TimeMs     int64             `json:"timeMs"`
+	SizeBytes  int64             `json:"sizeBytes"`
+	Headers    map[string]string `json:"headers,omitempty"`
+}
+
+// ============================================================================
+// ERROR INFO
+// ============================================================================
+
+// RunnerErrorInfo contains error details.
+type RunnerErrorInfo struct {
+	Type    string `json:"type"` // "network", "timeout", "script"
+	Message string `json:"message"`
+	Details string `json:"details,omitempty"`
+}
+
+// ============================================================================
+// REQUEST RESULT
+// ============================================================================
+
+// RequestResult captures the complete outcome of a single request.
+type RequestResult struct {
+	Request          RunnerRequestInfo   `json:"request"`
+	Response         *RunnerResponseInfo `json:"response,omitempty"`
+	PreScriptResult  *ScriptResult       `json:"preScript,omitempty"`
+	PostScriptResult *ScriptResult       `json:"postScript,omitempty"`
+	Error            *RunnerErrorInfo    `json:"error,omitempty"`
+	Duration         time.Duration       `json:"-"`
+	DurationMs       int64               `json:"durationMs"`
+	Index            int                 `json:"index"`
+	Status           ResultStatus        `json:"status"`
+}
+
+// NewRequestResult creates a pending result for a request.
+func NewRequestResult(req *CollectionRequest, index int) RequestResult {
+	return RequestResult{
+		Request: RunnerRequestInfo{
+			ID:     req.ID,
+			Name:   req.Name,
+			Method: string(req.Method),
+			URL:    req.URL,
+		},
+		Index:  index,
+		Status: ResultStatusPending,
+	}
+}
+
+// SetRunning marks the result as currently executing.
+func (r *RequestResult) SetRunning() {
+	r.Status = ResultStatusRunning
+}
+
+// SetCompleted finalizes the result with response data.
+func (r *RequestResult) SetCompleted(resp *Response, duration time.Duration) {
+	r.Response = &RunnerResponseInfo{
+		Status:     resp.StatusCode,
+		StatusText: resp.Status,
+		TimeMs:     resp.Time.Milliseconds(),
+		SizeBytes:  resp.Size,
+		Headers:    flattenHeaders(resp.Headers),
+	}
+	r.Duration = duration
+	r.DurationMs = duration.Milliseconds()
+	r.Status = ResultStatusPassed // Updated by SetScriptResults if failures
+}
+
+// SetError marks the result as failed with error details.
+func (r *RequestResult) SetError(errType, message, details string) {
+	r.Error = &RunnerErrorInfo{
+		Type:    errType,
+		Message: message,
+		Details: details,
+	}
+	r.Status = ResultStatusError
+}
+
+// SetScriptResults sets the pre and post script results.
+func (r *RequestResult) SetScriptResults(pre, post *ScriptResult) {
+	r.PreScriptResult = pre
+	r.PostScriptResult = post
+
+	// Update status based on assertions
+	if post != nil && post.HasAssertionFailures() {
+		r.Status = ResultStatusFailed
+	}
+}
+
+// SetSkipped marks the result as skipped.
+func (r *RequestResult) SetSkipped() {
+	r.Status = ResultStatusSkipped
+}
+
+// AssertionCount returns passed and failed assertion counts.
+func (r *RequestResult) AssertionCount() (passed, failed int) {
+	if r.PostScriptResult == nil {
+		return 0, 0
+	}
+	return r.PostScriptResult.PassedAssertionCount(), r.PostScriptResult.FailedAssertionCount()
+}
+
+// ============================================================================
+// RUN SESSION
+// ============================================================================
+
+// RunSession represents a single collection run execution.
+type RunSession struct {
+	// Metadata
+	ID          string    `json:"id"`
+	Collection  string    `json:"collection"`
+	FolderPath  []string  `json:"folderPath,omitempty"`
+	Environment string    `json:"environment"`
+	StartTime   time.Time `json:"startTime"`
+	EndTime     time.Time `json:"endTime,omitempty"`
+	Status      RunStatus `json:"status"`
+
+	// Configuration
+	Config RunConfig `json:"config"`
+
+	// Execution state
+	Results       []RequestResult `json:"results"`
+	CurrentIndex  int             `json:"-"`
+	TotalRequests int             `json:"totalRequests"`
+
+	// Session-scoped environment (modified by scripts)
+	SessionEnv *EnvironmentFile `json:"-"`
+}
+
+// NewRunSession creates a new run session.
+func NewRunSession(collection string, folderPath []string, env *EnvironmentFile, config RunConfig) *RunSession {
+	envName := ""
+	var sessionEnv *EnvironmentFile
+	if env != nil {
+		envName = env.Name
+		sessionEnv = env.Clone()
+	} else {
+		sessionEnv = &EnvironmentFile{
+			Name:      "default",
+			Variables: make(map[string]*EnvironmentVariable),
+		}
+	}
+
+	return &RunSession{
+		ID:            generateRunID(collection),
+		Collection:    collection,
+		FolderPath:    folderPath,
+		Environment:   envName,
+		Status:        RunStatusPending,
+		Config:        config,
+		Results:       make([]RequestResult, 0),
+		CurrentIndex:  0,
+		TotalRequests: 0,
+		SessionEnv:    sessionEnv,
+	}
+}
+
+// Start transitions the session to running state.
+func (s *RunSession) Start(totalRequests int) {
+	s.StartTime = time.Now()
+	s.Status = RunStatusRunning
+	s.TotalRequests = totalRequests
+}
+
+// Complete transitions the session to completed state.
+func (s *RunSession) Complete() {
+	s.EndTime = time.Now()
+	s.Status = RunStatusCompleted
+}
+
+// Cancel transitions the session to canceled state.
+func (s *RunSession) Cancel() {
+	s.EndTime = time.Now()
+	s.Status = RunStatusCancelled
+}
+
+// Stop transitions the session to stopped state (failure halt).
+func (s *RunSession) Stop() {
+	s.EndTime = time.Now()
+	s.Status = RunStatusStopped
+}
+
+// AddResult appends a request result and advances the index.
+func (s *RunSession) AddResult(result RequestResult) {
+	s.Results = append(s.Results, result)
+	s.CurrentIndex++
+}
+
+// IsTerminal returns true if the session is in a terminal state.
+func (s *RunSession) IsTerminal() bool {
+	return s.Status == RunStatusCompleted ||
+		s.Status == RunStatusCancelled ||
+		s.Status == RunStatusStopped
+}
+
+// Progress returns current/total as a string.
+func (s *RunSession) Progress() string {
+	return fmt.Sprintf("%d/%d", s.CurrentIndex, s.TotalRequests)
+}
+
+// ============================================================================
+// REPORT TYPES
+// ============================================================================
+
+// SessionInfo contains session metadata for the report.
+type SessionInfo struct {
+	ID          string    `json:"id"`
+	Collection  string    `json:"collection"`
+	FolderPath  []string  `json:"folderPath,omitempty"`
+	Environment string    `json:"environment"`
+	StartTime   string    `json:"startTime"`
+	EndTime     string    `json:"endTime"`
+	Status      string    `json:"status"`
+	Settings    RunConfig `json:"settings"`
+}
+
+// SummaryStats contains aggregated statistics.
+type SummaryStats struct {
+	TotalRequests     int   `json:"totalRequests"`
+	CompletedRequests int   `json:"completedRequests"`
+	SkippedRequests   int   `json:"skippedRequests"`
+	TotalAssertions   int   `json:"totalAssertions"`
+	PassedAssertions  int   `json:"passedAssertions"`
+	FailedAssertions  int   `json:"failedAssertions"`
+	Errors            int   `json:"errors"`
+	TotalDurationMs   int64 `json:"totalDurationMs"`
+}
+
+// RunReport is the complete JSON export structure.
+type RunReport struct {
+	Session SessionInfo     `json:"session"`
+	Summary SummaryStats    `json:"summary"`
+	Results []RequestResult `json:"results"`
+}
+
+// GenerateReport creates a report from a completed session.
+func (s *RunSession) GenerateReport() *RunReport {
+	report := &RunReport{
+		Session: SessionInfo{
+			ID:          s.ID,
+			Collection:  s.Collection,
+			FolderPath:  s.FolderPath,
+			Environment: s.Environment,
+			StartTime:   s.StartTime.Format(time.RFC3339),
+			EndTime:     s.EndTime.Format(time.RFC3339),
+			Status:      string(s.Status),
+			Settings:    s.Config,
+		},
+		Results: s.Results,
+	}
+
+	// Calculate summary
+	summary := SummaryStats{
+		TotalRequests: s.TotalRequests,
+	}
+
+	for _, r := range s.Results {
+		switch r.Status {
+		case ResultStatusPassed, ResultStatusFailed:
+			summary.CompletedRequests++
+			passed, failed := r.AssertionCount()
+			summary.TotalAssertions += passed + failed
+			summary.PassedAssertions += passed
+			summary.FailedAssertions += failed
+		case ResultStatusError:
+			summary.CompletedRequests++
+			summary.Errors++
+		case ResultStatusSkipped:
+			summary.SkippedRequests++
+		}
+		summary.TotalDurationMs += r.DurationMs
+	}
+
+	report.Summary = summary
+	return report
+}
+
+// ============================================================================
+// REQUEST COLLECTION FUNCTIONS
+// ============================================================================
+
+// CollectRequests gathers all requests from a folder recursively (depth-first).
+func CollectRequests(folder *Folder) []*CollectionRequest {
+	var requests []*CollectionRequest
+
+	// Add folder's direct requests first
+	for i := range folder.Requests {
+		requests = append(requests, &folder.Requests[i])
+	}
+
+	// Recurse into subfolders (depth-first)
+	for i := range folder.Folders {
+		requests = append(requests, CollectRequests(&folder.Folders[i])...)
+	}
+
+	return requests
+}
+
+// CollectFromCollection gathers requests from entire collection or specific folder.
+func CollectFromCollection(collection *CollectionFile, folderPath []string) []*CollectionRequest {
+	if len(folderPath) == 0 {
+		// Collect from entire collection
+		var requests []*CollectionRequest
+		for i := range collection.Requests {
+			requests = append(requests, &collection.Requests[i])
+		}
+		for i := range collection.Folders {
+			requests = append(requests, CollectRequests(&collection.Folders[i])...)
+		}
+		return requests
+	}
+
+	// Find specific folder
+	folder := collection.findFolder(collection.Folders, folderPath, 0)
+	if folder == nil {
+		return nil
+	}
+	return CollectRequests(folder)
+}
+
+// ============================================================================
+// EXPORT FUNCTION
+// ============================================================================
+
+// ExportRunReport saves the report to .lazycurl/reports/
+func ExportRunReport(report *RunReport) (string, error) {
+	// Ensure directory exists
+	dir := ".lazycurl/reports"
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create reports directory: %w", err)
+	}
+
+	// Generate filename with timestamp
+	filename := fmt.Sprintf("run_%s.json", time.Now().Format("20060102_150405"))
+	path := filepath.Join(dir, filename)
+
+	// Marshal and write
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal report: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return "", fmt.Errorf("failed to write report file: %w", err)
+	}
+
+	return path, nil
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+// generateRunID creates a unique run session ID.
+func generateRunID(collection string) string {
+	// Sanitize collection name
+	sanitized := sanitizeForID(collection)
+	return fmt.Sprintf("run_%d_%s", time.Now().Unix(), sanitized)
+}
+
+// sanitizeForID removes special characters from a string for use in IDs.
+func sanitizeForID(s string) string {
+	// Replace spaces with underscores
+	s = strings.ReplaceAll(s, " ", "_")
+	// Keep only alphanumeric and underscores
+	reg := regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	s = reg.ReplaceAllString(s, "")
+	// Limit length
+	if len(s) > 30 {
+		s = s[:30]
+	}
+	return strings.ToLower(s)
+}
+
+// flattenHeaders converts multi-value headers to single values.
+func flattenHeaders(headers map[string][]string) map[string]string {
+	if headers == nil {
+		return nil
+	}
+	result := make(map[string]string)
+	for k, v := range headers {
+		if len(v) > 0 {
+			result[k] = v[0]
+		}
+	}
+	return result
+}
+
+// GetSessionEnvVariables returns a simple map of environment variables for script execution.
+func (s *RunSession) GetSessionEnvVariables() map[string]string {
+	if s.SessionEnv == nil {
+		return make(map[string]string)
+	}
+	result := make(map[string]string)
+	for k, v := range s.SessionEnv.Variables {
+		if v.Active {
+			result[k] = v.Value
+		}
+	}
+	return result
+}
+
+// SetSessionEnvVariable sets a variable in the session environment.
+func (s *RunSession) SetSessionEnvVariable(key, value string) {
+	if s.SessionEnv == nil {
+		s.SessionEnv = &EnvironmentFile{
+			Name:      "session",
+			Variables: make(map[string]*EnvironmentVariable),
+		}
+	}
+	s.SessionEnv.SetVariable(key, value)
+}

--- a/internal/api/runner.go
+++ b/internal/api/runner.go
@@ -451,8 +451,9 @@ func ExportRunReport(report *RunReport) (string, error) {
 		return "", fmt.Errorf("failed to create reports directory: %w", err)
 	}
 
-	// Generate filename with timestamp
-	filename := fmt.Sprintf("run_%s.json", time.Now().Format("20060102_150405"))
+	// Generate filename with high-resolution timestamp to prevent collision
+	ts := time.Now()
+	filename := fmt.Sprintf("run_%s_%09d.json", ts.Format("20060102_150405"), ts.Nanosecond())
 	path := filepath.Join(dir, filename)
 
 	// Marshal and write
@@ -476,7 +477,7 @@ func ExportRunReport(report *RunReport) (string, error) {
 func generateRunID(collection string) string {
 	// Sanitize collection name
 	sanitized := sanitizeForID(collection)
-	return fmt.Sprintf("run_%d_%s", time.Now().Unix(), sanitized)
+	return fmt.Sprintf("run_%d_%s", time.Now().UnixNano(), sanitized)
 }
 
 // sanitizeForID removes special characters from a string for use in IDs.

--- a/internal/api/runner_test.go
+++ b/internal/api/runner_test.go
@@ -1,0 +1,854 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunStatus_String(t *testing.T) {
+	tests := []struct {
+		status RunStatus
+		want   string
+	}{
+		{RunStatusPending, "pending"},
+		{RunStatusRunning, "running"},
+		{RunStatusCompleted, "completed"},
+		{RunStatusCancelled, "canceled"},
+		{RunStatusStopped, "stopped"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("RunStatus.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResultStatus_String(t *testing.T) {
+	tests := []struct {
+		status ResultStatus
+		want   string
+	}{
+		{ResultStatusPending, "pending"},
+		{ResultStatusRunning, "running"},
+		{ResultStatusPassed, "passed"},
+		{ResultStatusFailed, "failed"},
+		{ResultStatusError, "error"},
+		{ResultStatusSkipped, "skipped"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("ResultStatus.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  RunConfig
+		wantErr error
+	}{
+		{
+			name:    "valid default",
+			config:  DefaultRunConfig(),
+			wantErr: nil,
+		},
+		{
+			name:    "valid with delay",
+			config:  RunConfig{DelayMs: 5000, Timeout: time.Second, ScriptTimeout: time.Second},
+			wantErr: nil,
+		},
+		{
+			name:    "valid max delay",
+			config:  RunConfig{DelayMs: 10000, Timeout: time.Second, ScriptTimeout: time.Second},
+			wantErr: nil,
+		},
+		{
+			name:    "negative delay",
+			config:  RunConfig{DelayMs: -1, Timeout: time.Second, ScriptTimeout: time.Second},
+			wantErr: ErrInvalidDelay,
+		},
+		{
+			name:    "excessive delay",
+			config:  RunConfig{DelayMs: 20000, Timeout: time.Second, ScriptTimeout: time.Second},
+			wantErr: ErrInvalidDelay,
+		},
+		{
+			name:    "zero timeout",
+			config:  RunConfig{DelayMs: 0, Timeout: 0, ScriptTimeout: time.Second},
+			wantErr: ErrInvalidTimeout,
+		},
+		{
+			name:    "negative timeout",
+			config:  RunConfig{DelayMs: 0, Timeout: -time.Second, ScriptTimeout: time.Second},
+			wantErr: ErrInvalidTimeout,
+		},
+		{
+			name:    "zero script timeout",
+			config:  RunConfig{DelayMs: 0, Timeout: time.Second, ScriptTimeout: 0},
+			wantErr: ErrInvalidScriptTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultRunConfig(t *testing.T) {
+	config := DefaultRunConfig()
+
+	if config.StopOnFailure != false {
+		t.Error("StopOnFailure should default to false")
+	}
+	if config.DelayMs != 0 {
+		t.Error("DelayMs should default to 0")
+	}
+	if config.Timeout != 30*time.Second {
+		t.Error("Timeout should default to 30s")
+	}
+	if config.ScriptTimeout != 5*time.Second {
+		t.Error("ScriptTimeout should default to 5s")
+	}
+
+	// Default config should be valid
+	if err := config.Validate(); err != nil {
+		t.Errorf("Default config should be valid, got error: %v", err)
+	}
+}
+
+func TestNewRequestResult(t *testing.T) {
+	req := &CollectionRequest{
+		ID:     "req_123",
+		Name:   "Test Request",
+		Method: GET,
+		URL:    "https://api.example.com/test",
+	}
+
+	result := NewRequestResult(req, 5)
+
+	if result.Request.ID != "req_123" {
+		t.Errorf("Request.ID = %v, want req_123", result.Request.ID)
+	}
+	if result.Request.Name != "Test Request" {
+		t.Errorf("Request.Name = %v, want Test Request", result.Request.Name)
+	}
+	if result.Request.Method != "GET" {
+		t.Errorf("Request.Method = %v, want GET", result.Request.Method)
+	}
+	if result.Index != 5 {
+		t.Errorf("Index = %v, want 5", result.Index)
+	}
+	if result.Status != ResultStatusPending {
+		t.Errorf("Status = %v, want pending", result.Status)
+	}
+}
+
+func TestRequestResult_SetRunning(t *testing.T) {
+	result := RequestResult{Status: ResultStatusPending}
+	result.SetRunning()
+
+	if result.Status != ResultStatusRunning {
+		t.Errorf("Status = %v, want running", result.Status)
+	}
+}
+
+func TestRequestResult_SetCompleted(t *testing.T) {
+	result := RequestResult{Status: ResultStatusRunning}
+	resp := &Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Time:       150 * time.Millisecond,
+		Size:       1024,
+		Headers:    map[string][]string{"Content-Type": {"application/json"}},
+	}
+
+	result.SetCompleted(resp, 200*time.Millisecond)
+
+	if result.Status != ResultStatusPassed {
+		t.Errorf("Status = %v, want passed", result.Status)
+	}
+	if result.Response == nil {
+		t.Fatal("Response should not be nil")
+	}
+	if result.Response.Status != 200 {
+		t.Errorf("Response.Status = %v, want 200", result.Response.Status)
+	}
+	if result.Response.TimeMs != 150 {
+		t.Errorf("Response.TimeMs = %v, want 150", result.Response.TimeMs)
+	}
+	if result.DurationMs != 200 {
+		t.Errorf("DurationMs = %v, want 200", result.DurationMs)
+	}
+}
+
+func TestRequestResult_SetError(t *testing.T) {
+	result := RequestResult{Status: ResultStatusRunning}
+	result.SetError("network", "connection refused", "dial tcp 127.0.0.1:8080: connect: connection refused")
+
+	if result.Status != ResultStatusError {
+		t.Errorf("Status = %v, want error", result.Status)
+	}
+	if result.Error == nil {
+		t.Fatal("Error should not be nil")
+	}
+	if result.Error.Type != "network" {
+		t.Errorf("Error.Type = %v, want network", result.Error.Type)
+	}
+	if result.Error.Message != "connection refused" {
+		t.Errorf("Error.Message = %v, want connection refused", result.Error.Message)
+	}
+}
+
+func TestRequestResult_SetScriptResults(t *testing.T) {
+	t.Run("with passing assertions", func(t *testing.T) {
+		result := RequestResult{Status: ResultStatusPassed}
+		postResult := &ScriptResult{
+			Assertions: []AssertionResult{
+				{Name: "test1", Passed: true},
+				{Name: "test2", Passed: true},
+			},
+		}
+
+		result.SetScriptResults(nil, postResult)
+
+		if result.Status != ResultStatusPassed {
+			t.Errorf("Status = %v, want passed", result.Status)
+		}
+	})
+
+	t.Run("with failing assertions", func(t *testing.T) {
+		result := RequestResult{Status: ResultStatusPassed}
+		postResult := &ScriptResult{
+			Assertions: []AssertionResult{
+				{Name: "test1", Passed: true},
+				{Name: "test2", Passed: false},
+			},
+		}
+
+		result.SetScriptResults(nil, postResult)
+
+		if result.Status != ResultStatusFailed {
+			t.Errorf("Status = %v, want failed", result.Status)
+		}
+	})
+}
+
+func TestRequestResult_AssertionCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		postResult *ScriptResult
+		wantPassed int
+		wantFailed int
+	}{
+		{
+			name:       "nil post result",
+			postResult: nil,
+			wantPassed: 0,
+			wantFailed: 0,
+		},
+		{
+			name: "all passing",
+			postResult: &ScriptResult{
+				Assertions: []AssertionResult{
+					{Name: "test1", Passed: true},
+					{Name: "test2", Passed: true},
+				},
+			},
+			wantPassed: 2,
+			wantFailed: 0,
+		},
+		{
+			name: "mixed results",
+			postResult: &ScriptResult{
+				Assertions: []AssertionResult{
+					{Name: "test1", Passed: true},
+					{Name: "test2", Passed: false},
+					{Name: "test3", Passed: true},
+					{Name: "test4", Passed: false},
+				},
+			},
+			wantPassed: 2,
+			wantFailed: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RequestResult{PostScriptResult: tt.postResult}
+			passed, failed := result.AssertionCount()
+
+			if passed != tt.wantPassed {
+				t.Errorf("passed = %v, want %v", passed, tt.wantPassed)
+			}
+			if failed != tt.wantFailed {
+				t.Errorf("failed = %v, want %v", failed, tt.wantFailed)
+			}
+		})
+	}
+}
+
+func TestNewRunSession(t *testing.T) {
+	env := &EnvironmentFile{
+		Name: "development",
+		Variables: map[string]*EnvironmentVariable{
+			"base_url": {Value: "https://api.example.com", Active: true},
+		},
+	}
+	config := DefaultRunConfig()
+
+	session := NewRunSession("My API", []string{"Users"}, env, config)
+
+	if session.Collection != "My API" {
+		t.Errorf("Collection = %v, want My API", session.Collection)
+	}
+	if len(session.FolderPath) != 1 || session.FolderPath[0] != "Users" {
+		t.Errorf("FolderPath = %v, want [Users]", session.FolderPath)
+	}
+	if session.Environment != "development" {
+		t.Errorf("Environment = %v, want development", session.Environment)
+	}
+	if session.Status != RunStatusPending {
+		t.Errorf("Status = %v, want pending", session.Status)
+	}
+	if session.ID == "" {
+		t.Error("ID should not be empty")
+	}
+	if session.SessionEnv == nil {
+		t.Error("SessionEnv should not be nil")
+	}
+	// Verify it's a clone
+	if session.SessionEnv == env {
+		t.Error("SessionEnv should be a clone, not the original")
+	}
+}
+
+func TestNewRunSession_NilEnv(t *testing.T) {
+	config := DefaultRunConfig()
+	session := NewRunSession("Test", nil, nil, config)
+
+	if session.SessionEnv == nil {
+		t.Error("SessionEnv should be created even with nil input")
+	}
+	if session.Environment != "" {
+		t.Errorf("Environment should be empty, got %v", session.Environment)
+	}
+}
+
+func TestRunSession_StateTransitions(t *testing.T) {
+	env := &EnvironmentFile{
+		Name:      "test",
+		Variables: map[string]*EnvironmentVariable{},
+	}
+	session := NewRunSession("Test", nil, env, DefaultRunConfig())
+
+	// Initial state
+	if session.Status != RunStatusPending {
+		t.Errorf("Expected pending status, got %v", session.Status)
+	}
+	if session.IsTerminal() {
+		t.Error("Pending session should not be terminal")
+	}
+
+	// Start
+	session.Start(5)
+	if session.Status != RunStatusRunning {
+		t.Errorf("Expected running status, got %v", session.Status)
+	}
+	if session.TotalRequests != 5 {
+		t.Errorf("TotalRequests = %v, want 5", session.TotalRequests)
+	}
+	if session.StartTime.IsZero() {
+		t.Error("StartTime should be set")
+	}
+	if session.IsTerminal() {
+		t.Error("Running session should not be terminal")
+	}
+
+	// Complete
+	session.Complete()
+	if session.Status != RunStatusCompleted {
+		t.Errorf("Expected completed status, got %v", session.Status)
+	}
+	if session.EndTime.IsZero() {
+		t.Error("EndTime should be set")
+	}
+	if !session.IsTerminal() {
+		t.Error("Completed session should be terminal")
+	}
+}
+
+func TestRunSession_Cancel(t *testing.T) {
+	session := NewRunSession("Test", nil, nil, DefaultRunConfig())
+	session.Start(5)
+	session.Cancel()
+
+	if session.Status != RunStatusCancelled {
+		t.Errorf("Expected canceled status, got %v", session.Status)
+	}
+	if !session.IsTerminal() {
+		t.Error("Canceled session should be terminal")
+	}
+}
+
+func TestRunSession_Stop(t *testing.T) {
+	session := NewRunSession("Test", nil, nil, DefaultRunConfig())
+	session.Start(5)
+	session.Stop()
+
+	if session.Status != RunStatusStopped {
+		t.Errorf("Expected stopped status, got %v", session.Status)
+	}
+	if !session.IsTerminal() {
+		t.Error("Stopped session should be terminal")
+	}
+}
+
+func TestRunSession_AddResult(t *testing.T) {
+	session := NewRunSession("Test", nil, nil, DefaultRunConfig())
+	session.Start(3)
+
+	result1 := RequestResult{Index: 0, Status: ResultStatusPassed}
+	result2 := RequestResult{Index: 1, Status: ResultStatusFailed}
+
+	session.AddResult(result1)
+	if session.CurrentIndex != 1 {
+		t.Errorf("CurrentIndex = %v, want 1", session.CurrentIndex)
+	}
+	if len(session.Results) != 1 {
+		t.Errorf("len(Results) = %v, want 1", len(session.Results))
+	}
+
+	session.AddResult(result2)
+	if session.CurrentIndex != 2 {
+		t.Errorf("CurrentIndex = %v, want 2", session.CurrentIndex)
+	}
+	if len(session.Results) != 2 {
+		t.Errorf("len(Results) = %v, want 2", len(session.Results))
+	}
+}
+
+func TestRunSession_Progress(t *testing.T) {
+	session := NewRunSession("Test", nil, nil, DefaultRunConfig())
+	session.Start(10)
+	session.CurrentIndex = 3
+
+	progress := session.Progress()
+	if progress != "3/10" {
+		t.Errorf("Progress() = %v, want 3/10", progress)
+	}
+}
+
+func TestCollectRequests(t *testing.T) {
+	folder := &Folder{
+		Name: "Test",
+		Requests: []CollectionRequest{
+			{ID: "1", Name: "First"},
+			{ID: "2", Name: "Second"},
+		},
+		Folders: []Folder{
+			{
+				Name: "Nested",
+				Requests: []CollectionRequest{
+					{ID: "3", Name: "Nested First"},
+				},
+			},
+		},
+	}
+
+	requests := CollectRequests(folder)
+
+	if len(requests) != 3 {
+		t.Errorf("Expected 3 requests, got %d", len(requests))
+	}
+
+	// Verify order (depth-first: folder requests first, then subfolders)
+	expectedNames := []string{"First", "Second", "Nested First"}
+	for i, req := range requests {
+		if req.Name != expectedNames[i] {
+			t.Errorf("Expected %s at index %d, got %s", expectedNames[i], i, req.Name)
+		}
+	}
+}
+
+func TestCollectRequests_Empty(t *testing.T) {
+	folder := &Folder{
+		Name:     "Empty",
+		Requests: []CollectionRequest{},
+		Folders:  []Folder{},
+	}
+
+	requests := CollectRequests(folder)
+
+	if len(requests) != 0 {
+		t.Errorf("Expected 0 requests, got %d", len(requests))
+	}
+}
+
+func TestCollectRequests_Nested(t *testing.T) {
+	folder := &Folder{
+		Name: "Root",
+		Requests: []CollectionRequest{
+			{ID: "1", Name: "Root Request"},
+		},
+		Folders: []Folder{
+			{
+				Name: "Level1",
+				Requests: []CollectionRequest{
+					{ID: "2", Name: "Level1 Request"},
+				},
+				Folders: []Folder{
+					{
+						Name: "Level2",
+						Requests: []CollectionRequest{
+							{ID: "3", Name: "Level2 Request"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	requests := CollectRequests(folder)
+
+	if len(requests) != 3 {
+		t.Errorf("Expected 3 requests, got %d", len(requests))
+	}
+
+	expectedNames := []string{"Root Request", "Level1 Request", "Level2 Request"}
+	for i, req := range requests {
+		if req.Name != expectedNames[i] {
+			t.Errorf("Expected %s at index %d, got %s", expectedNames[i], i, req.Name)
+		}
+	}
+}
+
+func TestCollectFromCollection(t *testing.T) {
+	collection := &CollectionFile{
+		Name: "API",
+		Requests: []CollectionRequest{
+			{ID: "1", Name: "Root Request"},
+		},
+		Folders: []Folder{
+			{
+				Name: "Users",
+				Requests: []CollectionRequest{
+					{ID: "2", Name: "Get Users"},
+					{ID: "3", Name: "Create User"},
+				},
+			},
+		},
+	}
+
+	t.Run("entire collection", func(t *testing.T) {
+		requests := CollectFromCollection(collection, nil)
+		if len(requests) != 3 {
+			t.Errorf("Expected 3 requests, got %d", len(requests))
+		}
+	})
+
+	t.Run("specific folder", func(t *testing.T) {
+		requests := CollectFromCollection(collection, []string{"Users"})
+		if len(requests) != 2 {
+			t.Errorf("Expected 2 requests, got %d", len(requests))
+		}
+	})
+
+	t.Run("non-existent folder", func(t *testing.T) {
+		requests := CollectFromCollection(collection, []string{"NonExistent"})
+		if requests != nil {
+			t.Errorf("Expected nil for non-existent folder, got %v", requests)
+		}
+	})
+}
+
+func TestRunReport_Generate(t *testing.T) {
+	session := NewRunSession("Test API", nil, nil, DefaultRunConfig())
+	session.Start(3)
+	session.StartTime = time.Date(2026, 1, 18, 10, 0, 0, 0, time.UTC)
+
+	// Add some results
+	result1 := RequestResult{
+		Index:      0,
+		Status:     ResultStatusPassed,
+		DurationMs: 100,
+		PostScriptResult: &ScriptResult{
+			Assertions: []AssertionResult{
+				{Passed: true},
+				{Passed: true},
+			},
+		},
+	}
+	result2 := RequestResult{
+		Index:      1,
+		Status:     ResultStatusFailed,
+		DurationMs: 150,
+		PostScriptResult: &ScriptResult{
+			Assertions: []AssertionResult{
+				{Passed: true},
+				{Passed: false},
+			},
+		},
+	}
+	result3 := RequestResult{
+		Index:      2,
+		Status:     ResultStatusError,
+		DurationMs: 50,
+	}
+
+	session.Results = []RequestResult{result1, result2, result3}
+	session.Complete()
+	session.EndTime = time.Date(2026, 1, 18, 10, 0, 1, 0, time.UTC)
+
+	report := session.GenerateReport()
+
+	// Verify session info
+	if report.Session.Collection != "Test API" {
+		t.Errorf("Session.Collection = %v, want Test API", report.Session.Collection)
+	}
+	if report.Session.Status != "completed" {
+		t.Errorf("Session.Status = %v, want completed", report.Session.Status)
+	}
+
+	// Verify summary
+	if report.Summary.TotalRequests != 3 {
+		t.Errorf("Summary.TotalRequests = %v, want 3", report.Summary.TotalRequests)
+	}
+	if report.Summary.CompletedRequests != 3 {
+		t.Errorf("Summary.CompletedRequests = %v, want 3", report.Summary.CompletedRequests)
+	}
+	if report.Summary.PassedAssertions != 3 {
+		t.Errorf("Summary.PassedAssertions = %v, want 3", report.Summary.PassedAssertions)
+	}
+	if report.Summary.FailedAssertions != 1 {
+		t.Errorf("Summary.FailedAssertions = %v, want 1", report.Summary.FailedAssertions)
+	}
+	if report.Summary.Errors != 1 {
+		t.Errorf("Summary.Errors = %v, want 1", report.Summary.Errors)
+	}
+	if report.Summary.TotalDurationMs != 300 {
+		t.Errorf("Summary.TotalDurationMs = %v, want 300", report.Summary.TotalDurationMs)
+	}
+}
+
+func TestExportRunReport(t *testing.T) {
+	// Create temp directory for test
+	tmpDir := t.TempDir()
+	originalDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp dir: %v", err)
+	}
+	defer func() { _ = os.Chdir(originalDir) }()
+
+	session := NewRunSession("Test", nil, nil, DefaultRunConfig())
+	session.Start(1)
+	session.Complete()
+	report := session.GenerateReport()
+
+	path, err := ExportRunReport(report)
+	if err != nil {
+		t.Fatalf("ExportRunReport() error = %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("Report file was not created at %s", path)
+	}
+
+	// Verify directory was created
+	if _, err := os.Stat(".lazycurl/reports"); os.IsNotExist(err) {
+		t.Error("Reports directory was not created")
+	}
+
+	// Verify file content is valid JSON
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read report file: %v", err)
+	}
+
+	var parsed RunReport
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Report is not valid JSON: %v", err)
+	}
+}
+
+func TestFlattenHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string][]string
+		expect map[string]string
+	}{
+		{
+			name:   "nil input",
+			input:  nil,
+			expect: nil,
+		},
+		{
+			name:   "empty input",
+			input:  map[string][]string{},
+			expect: map[string]string{},
+		},
+		{
+			name: "single values",
+			input: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			expect: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+		{
+			name: "multiple values takes first",
+			input: map[string][]string{
+				"Accept": {"application/json", "text/plain"},
+			},
+			expect: map[string]string{
+				"Accept": "application/json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := flattenHeaders(tt.input)
+			if tt.expect == nil {
+				if result != nil {
+					t.Errorf("Expected nil, got %v", result)
+				}
+				return
+			}
+			if len(result) != len(tt.expect) {
+				t.Errorf("Length mismatch: got %d, want %d", len(result), len(tt.expect))
+			}
+			for k, v := range tt.expect {
+				if result[k] != v {
+					t.Errorf("result[%s] = %s, want %s", k, result[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeForID(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"Simple", "simple"},
+		{"With Spaces", "with_spaces"},
+		{"With-Dashes", "withdashes"},
+		{"With.Dots", "withdots"},
+		{"Special@#$%", "special"},
+		{"A Very Long Name That Exceeds Thirty Characters", "a_very_long_name_that_exceeds_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := sanitizeForID(tt.input)
+			if result != tt.expect {
+				t.Errorf("sanitizeForID(%s) = %s, want %s", tt.input, result, tt.expect)
+			}
+		})
+	}
+}
+
+func TestGenerateRunID(t *testing.T) {
+	id1 := generateRunID("Test Collection")
+	id2 := generateRunID("Test Collection")
+
+	// IDs should start with "run_"
+	if id1[:4] != "run_" {
+		t.Errorf("ID should start with 'run_', got %s", id1)
+	}
+
+	// IDs should contain timestamp and sanitized name
+	if len(id1) < 10 {
+		t.Errorf("ID seems too short: %s", id1)
+	}
+
+	// IDs generated at different times should differ (or at least be unique format)
+	// Note: This might occasionally fail if both are generated in the same second
+	// but the format should still be valid
+	if id1 == "" || id2 == "" {
+		t.Error("Generated IDs should not be empty")
+	}
+}
+
+func TestRunSession_GetSessionEnvVariables(t *testing.T) {
+	env := &EnvironmentFile{
+		Name: "test",
+		Variables: map[string]*EnvironmentVariable{
+			"active_var":   {Value: "active_value", Active: true},
+			"inactive_var": {Value: "inactive_value", Active: false},
+		},
+	}
+
+	session := NewRunSession("Test", nil, env, DefaultRunConfig())
+	vars := session.GetSessionEnvVariables()
+
+	if vars["active_var"] != "active_value" {
+		t.Errorf("active_var = %v, want active_value", vars["active_var"])
+	}
+	if _, exists := vars["inactive_var"]; exists {
+		t.Error("inactive_var should not be included")
+	}
+}
+
+func TestRunSession_SetSessionEnvVariable(t *testing.T) {
+	session := NewRunSession("Test", nil, nil, DefaultRunConfig())
+
+	session.SetSessionEnvVariable("new_var", "new_value")
+
+	vars := session.GetSessionEnvVariables()
+	if vars["new_var"] != "new_value" {
+		t.Errorf("new_var = %v, want new_value", vars["new_var"])
+	}
+}
+
+func TestExportRunReport_DirectoryPermissions(t *testing.T) {
+	// Skip if running as root (root can write anywhere)
+	if os.Getuid() == 0 {
+		t.Skip("Skipping permission test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+	originalDir, _ := os.Getwd()
+
+	// Create a read-only directory scenario would be complex
+	// Just verify normal operation works
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp dir: %v", err)
+	}
+	defer func() { _ = os.Chdir(originalDir) }()
+
+	session := NewRunSession("Test", nil, nil, DefaultRunConfig())
+	session.Start(1)
+	session.Complete()
+	report := session.GenerateReport()
+
+	path, err := ExportRunReport(report)
+	if err != nil {
+		t.Fatalf("ExportRunReport() error = %v", err)
+	}
+
+	// Verify the path is in the expected directory
+	expectedDir := filepath.Join(".lazycurl", "reports")
+	if filepath.Dir(path) != expectedDir {
+		t.Errorf("Report path = %s, expected dir %s", path, expectedDir)
+	}
+}

--- a/internal/api/runner_test.go
+++ b/internal/api/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -821,6 +822,10 @@ func TestRunSession_SetSessionEnvVariable(t *testing.T) {
 }
 
 func TestExportRunReport_DirectoryPermissions(t *testing.T) {
+	// Skip on Windows (os.Getuid not available)
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping permission test on Windows")
+	}
 	// Skip if running as root (root can write anywhere)
 	if os.Getuid() == 0 {
 		t.Skip("Skipping permission test when running as root")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ type KeyBindings struct {
 	ImportCurl       []string `yaml:"import_curl"`
 	ExportCurl       []string `yaml:"export_curl"`
 	ImportOpenAPI    []string `yaml:"import_openapi"`
+	RunCollection    []string `yaml:"run_collection"`
 }
 
 // Environment represents an environment with variables
@@ -127,6 +128,7 @@ func DefaultKeyBindings() KeyBindings {
 		ImportCurl:       []string{"ctrl+i"},
 		ExportCurl:       []string{"ctrl+e"},
 		ImportOpenAPI:    []string{"ctrl+o"},
+		RunCollection:    []string{"ctrl+r"},
 	}
 }
 

--- a/internal/ui/collections_view.go
+++ b/internal/ui/collections_view.go
@@ -510,3 +510,37 @@ func (c *CollectionsView) GetJumpTargets(startRow, startCol int) []JumpTarget {
 
 	return targets
 }
+
+// GetSelectedCollection returns the collection file for the currently selected node.
+// If the selected node is inside a collection (folder or request), it returns that collection.
+// Returns nil if no collection is selected.
+func (c *CollectionsView) GetSelectedCollection() *api.CollectionFile {
+	if c.tree == nil {
+		return nil
+	}
+	selectedNode := c.tree.Selected()
+	if selectedNode == nil {
+		return nil
+	}
+	return c.FindCollectionByNode(selectedNode)
+}
+
+// GetSelectedFolderPath returns the folder path for the currently selected node.
+// If a folder is selected, it returns the path to that folder.
+// If a request is selected, it returns the path to its parent folder.
+// If a collection root is selected, it returns an empty slice.
+func (c *CollectionsView) GetSelectedFolderPath() []string {
+	if c.tree == nil {
+		return nil
+	}
+	selectedNode := c.tree.Selected()
+	if selectedNode == nil {
+		return nil
+	}
+	// If it's a folder, include the folder in the path
+	if selectedNode.Type == components.FolderNode {
+		return c.GetFolderPathIncluding(selectedNode)
+	}
+	// Otherwise, get the parent folder path
+	return c.GetFolderPath(selectedNode)
+}

--- a/internal/ui/runner_commands.go
+++ b/internal/ui/runner_commands.go
@@ -1,0 +1,393 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/kbrdn1/LazyCurl/internal/api"
+)
+
+// ============================================================================
+// RUNNER COMMAND FUNCTIONS
+// ============================================================================
+
+// ExecuteCollectionRunCmd initializes and starts a collection run.
+func ExecuteCollectionRunCmd(
+	collection *api.CollectionFile,
+	folderPath []string,
+	env *api.EnvironmentFile,
+	config api.RunConfig,
+) tea.Cmd {
+	return func() tea.Msg {
+		// Validate configuration
+		if err := config.Validate(); err != nil {
+			return RunnerErrorMsg{Error: err}
+		}
+
+		// Collect requests from collection or folder
+		requests := api.CollectFromCollection(collection, folderPath)
+		if len(requests) == 0 {
+			return RunnerErrorMsg{Error: api.ErrNoRequests}
+		}
+
+		// Create session
+		session := api.NewRunSession(collection.Name, folderPath, env, config)
+		session.Start(len(requests))
+
+		return RunnerStartedMsg{
+			Session:  session,
+			Requests: requests,
+		}
+	}
+}
+
+// ExecuteNextRequestCmd executes the next request in the run.
+func ExecuteNextRequestCmd(
+	session *api.RunSession,
+	requests []*api.CollectionRequest,
+	client *api.Client,
+	executor api.ScriptExecutor,
+) tea.Cmd {
+	return func() tea.Msg {
+		// Check if run is already complete or canceled
+		if session.IsTerminal() {
+			report := session.GenerateReport()
+			return RunnerCompleteMsg{
+				Session: session,
+				Report:  report,
+			}
+		}
+
+		// Check if all requests completed
+		if session.CurrentIndex >= len(requests) {
+			session.Complete()
+			report := session.GenerateReport()
+			return RunnerCompleteMsg{
+				Session: session,
+				Report:  report,
+			}
+		}
+
+		// Get current request
+		collReq := requests[session.CurrentIndex]
+		result := api.NewRequestResult(collReq, session.CurrentIndex)
+		result.SetRunning()
+
+		startTime := time.Now()
+
+		// Convert to HTTP request
+		httpReq := collReq.ToRequest()
+
+		// Execute pre-request script FIRST if present
+		// This allows scripts to modify environment variables before substitution
+		var preScriptResult *api.ScriptResult
+		preScript := getPreRequestScript(collReq)
+		if preScript != "" {
+			// Create script request from raw (unsubstituted) HTTP request
+			scriptReq := api.NewScriptRequestFromHTTP(httpReq)
+			env := sessionEnvToEnvironment(session.SessionEnv)
+
+			var err error
+			preScriptResult, err = executor.ExecutePreRequest(preScript, scriptReq, env)
+			if err != nil {
+				result.SetError("script", "Pre-request script error", err.Error())
+				result.Duration = time.Since(startTime)
+				result.DurationMs = result.Duration.Milliseconds()
+				session.AddResult(result)
+
+				// Check stop on failure
+				if session.Config.StopOnFailure {
+					session.Stop()
+					markRemainingSkipped(session, requests)
+					return RunnerCompleteMsg{
+						Session: session,
+						Report:  session.GenerateReport(),
+					}
+				}
+
+				return runnerRequestComplete(session, result)
+			}
+
+			// Apply environment changes from pre-request script FIRST
+			// This ensures new variables are available for substitution
+			applyEnvChanges(session, preScriptResult)
+
+			// Apply script modifications to request (URL, headers, body changes)
+			applyScriptModifications(httpReq, scriptReq)
+		}
+
+		// Apply variable substitution from session environment AFTER pre-request script
+		// This allows scripts to define variables that get substituted
+		httpReq = api.ReplaceVariablesInRequest(httpReq, session.SessionEnv)
+
+		// Store resolved URL
+		result.Request.ResolvedURL = httpReq.URL
+
+		// Send HTTP request
+		resp, err := client.Send(httpReq)
+		if err != nil {
+			errType := "network"
+			if isTimeoutError(err) {
+				errType = "timeout"
+			}
+			result.SetError(errType, "HTTP request failed", err.Error())
+			result.Duration = time.Since(startTime)
+			result.DurationMs = result.Duration.Milliseconds()
+			result.PreScriptResult = preScriptResult
+			session.AddResult(result)
+
+			// Check stop on failure
+			if session.Config.StopOnFailure {
+				session.Stop()
+				markRemainingSkipped(session, requests)
+				return RunnerCompleteMsg{
+					Session: session,
+					Report:  session.GenerateReport(),
+				}
+			}
+
+			return runnerRequestComplete(session, result)
+		}
+
+		// Set completed with response
+		result.SetCompleted(resp, time.Since(startTime))
+
+		// Execute post-response script if present
+		var postScriptResult *api.ScriptResult
+		postScript := getPostResponseScript(collReq)
+		if postScript != "" {
+			scriptReq := api.NewScriptRequestFromHTTP(httpReq)
+			scriptResp := createScriptResponseFromHTTP(resp)
+			env := sessionEnvToEnvironment(session.SessionEnv)
+
+			var err error
+			postScriptResult, err = executor.ExecutePostResponse(postScript, scriptReq, scriptResp, env)
+			if err != nil {
+				result.SetError("script", "Post-response script error", err.Error())
+			} else {
+				// Apply environment changes from post-response script
+				applyEnvChanges(session, postScriptResult)
+			}
+		}
+
+		// Set script results
+		result.SetScriptResults(preScriptResult, postScriptResult)
+
+		// Finalize timing
+		result.Duration = time.Since(startTime)
+		result.DurationMs = result.Duration.Milliseconds()
+
+		// Add result to session
+		session.AddResult(result)
+
+		// Check stop on failure (for failed assertions)
+		if session.Config.StopOnFailure && (result.Status == api.ResultStatusFailed || result.Status == api.ResultStatusError) {
+			session.Stop()
+			markRemainingSkipped(session, requests)
+			return RunnerCompleteMsg{
+				Session: session,
+				Report:  session.GenerateReport(),
+			}
+		}
+
+		return runnerRequestComplete(session, result)
+	}
+}
+
+// DelayCmd returns a command that waits for the specified delay.
+func DelayCmd(delayMs int) tea.Cmd {
+	if delayMs <= 0 {
+		return nil
+	}
+	return tea.Tick(time.Duration(delayMs)*time.Millisecond, func(t time.Time) tea.Msg {
+		return RunnerDelayCompleteMsg{}
+	})
+}
+
+// ExportRunReportCmd exports the run report to a file.
+func ExportRunReportCmd(report *api.RunReport) tea.Cmd {
+	return func() tea.Msg {
+		path, err := api.ExportRunReport(report)
+		return RunnerExportedMsg{
+			FilePath: path,
+			Error:    err,
+		}
+	}
+}
+
+// CancelRunCmd cancels the current run.
+func CancelRunCmd(session *api.RunSession, requests []*api.CollectionRequest) tea.Cmd {
+	return func() tea.Msg {
+		session.Cancel()
+		markRemainingSkipped(session, requests)
+		return RunnerCancelledMsg{
+			Session: session,
+			Report:  session.GenerateReport(),
+		}
+	}
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+// runnerRequestComplete creates a RunnerRequestCompleteMsg.
+func runnerRequestComplete(session *api.RunSession, result api.RequestResult) tea.Msg {
+	return RunnerRequestCompleteMsg{
+		Result:  result,
+		Session: session,
+	}
+}
+
+// markRemainingSkipped marks all remaining requests as skipped.
+func markRemainingSkipped(session *api.RunSession, requests []*api.CollectionRequest) {
+	for i := session.CurrentIndex; i < len(requests); i++ {
+		result := api.NewRequestResult(requests[i], i)
+		result.SetSkipped()
+		session.Results = append(session.Results, result)
+	}
+}
+
+// sessionEnvToEnvironment converts EnvironmentFile to Environment for script execution.
+func sessionEnvToEnvironment(envFile *api.EnvironmentFile) *api.Environment {
+	if envFile == nil {
+		return &api.Environment{
+			Name:      "default",
+			Variables: make(map[string]string),
+		}
+	}
+
+	env := &api.Environment{
+		Name:      envFile.Name,
+		Variables: make(map[string]string),
+	}
+	for k, v := range envFile.Variables {
+		if v.Active {
+			env.Variables[k] = v.Value
+		}
+	}
+	return env
+}
+
+// getPreRequestScript extracts the pre-request script from a CollectionRequest.
+func getPreRequestScript(req *api.CollectionRequest) string {
+	if req.Scripts == nil {
+		return ""
+	}
+	return req.Scripts.PreRequest
+}
+
+// getPostResponseScript extracts the post-response script from a CollectionRequest.
+func getPostResponseScript(req *api.CollectionRequest) string {
+	if req.Scripts == nil {
+		return ""
+	}
+	return req.Scripts.PostRequest
+}
+
+// createScriptResponseFromHTTP creates a ScriptResponse from an HTTP Response.
+func createScriptResponseFromHTTP(resp *api.Response) *api.ScriptResponse {
+	if resp == nil {
+		return api.NewScriptResponseFromData(0, "", nil, "", 0)
+	}
+
+	// Flatten headers
+	headers := make(map[string]string)
+	for k, v := range resp.Headers {
+		if len(v) > 0 {
+			headers[k] = v[0]
+		}
+	}
+
+	return api.NewScriptResponseFromData(
+		resp.StatusCode,
+		resp.Status,
+		headers,
+		resp.Body,
+		resp.Time.Milliseconds(),
+	)
+}
+
+// applyScriptModifications applies script modifications to the HTTP request.
+func applyScriptModifications(httpReq *api.Request, scriptReq *api.ScriptRequest) {
+	// Apply URL changes
+	if scriptReq.URL() != "" && scriptReq.IsModified() {
+		httpReq.URL = scriptReq.URL()
+	}
+
+	// Apply header changes
+	for k, v := range scriptReq.Headers() {
+		httpReq.Headers[k] = v
+	}
+
+	// Apply body changes
+	if scriptReq.IsBodyModified() {
+		body := scriptReq.Body()
+		httpReq.Body = &body
+	}
+}
+
+// applyEnvChanges applies environment changes from script result to session.
+func applyEnvChanges(session *api.RunSession, result *api.ScriptResult) {
+	if result == nil {
+		return
+	}
+	for _, change := range result.EnvChanges {
+		switch change.Type {
+		case api.EnvChangeSet:
+			session.SetSessionEnvVariable(change.Name, change.Value)
+		case api.EnvChangeUnset:
+			if session.SessionEnv != nil {
+				delete(session.SessionEnv.Variables, change.Name)
+			}
+		}
+	}
+}
+
+// isTimeoutError checks if an error is a timeout error.
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "timeout") || strings.Contains(errStr, "deadline exceeded")
+}
+
+// ============================================================================
+// CHAIN COMMANDS
+// ============================================================================
+
+// ChainNextRequestCmd chains the next request execution with optional delay.
+func ChainNextRequestCmd(
+	session *api.RunSession,
+	requests []*api.CollectionRequest,
+	client *api.Client,
+	executor api.ScriptExecutor,
+) tea.Cmd {
+	// Check for delay
+	if session.Config.DelayMs > 0 {
+		// Return delay command, then execute next
+		return tea.Sequence(
+			DelayCmd(session.Config.DelayMs),
+			func() tea.Msg {
+				return RunnerExecuteNextMsg{}
+			},
+		)
+	}
+
+	// No delay, execute immediately
+	return func() tea.Msg {
+		return RunnerExecuteNextMsg{}
+	}
+}
+
+// FormatRunnerError formats a runner error for display.
+func FormatRunnerError(err error) string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("Runner error: %s", err.Error())
+}

--- a/internal/ui/runner_messages.go
+++ b/internal/ui/runner_messages.go
@@ -1,0 +1,88 @@
+package ui
+
+import (
+	"github.com/kbrdn1/LazyCurl/internal/api"
+)
+
+// ============================================================================
+// RUNNER MESSAGES
+// ============================================================================
+
+// RunnerStartMsg signals the runner should start executing.
+type RunnerStartMsg struct {
+	Collection *api.CollectionFile
+	FolderPath []string
+	Config     api.RunConfig
+}
+
+// RunnerStartedMsg signals the run has begun.
+type RunnerStartedMsg struct {
+	Session  *api.RunSession
+	Requests []*api.CollectionRequest
+}
+
+// RunnerProgressMsg signals progress during execution.
+type RunnerProgressMsg struct {
+	CurrentIndex  int
+	TotalRequests int
+	CurrentName   string
+	Status        string // "executing", "waiting", "scripting"
+}
+
+// RunnerRequestCompleteMsg signals a single request has completed.
+type RunnerRequestCompleteMsg struct {
+	Result  api.RequestResult
+	Session *api.RunSession
+}
+
+// RunnerCompleteMsg signals the entire run has finished.
+type RunnerCompleteMsg struct {
+	Session *api.RunSession
+	Report  *api.RunReport
+}
+
+// RunnerErrorMsg signals a fatal runner error.
+type RunnerErrorMsg struct {
+	Error error
+}
+
+// RunnerCancelMsg signals the user wants to cancel.
+type RunnerCancelMsg struct{}
+
+// RunnerCancelledMsg signals the run was canceled.
+type RunnerCancelledMsg struct {
+	Session *api.RunSession
+	Report  *api.RunReport
+}
+
+// RunnerExportMsg signals the user wants to export results.
+type RunnerExportMsg struct{}
+
+// RunnerExportedMsg signals the export completed.
+type RunnerExportedMsg struct {
+	FilePath string
+	Error    error
+}
+
+// RunnerShowModalMsg signals the modal should be shown.
+type RunnerShowModalMsg struct{}
+
+// RunnerHideModalMsg signals the modal should be hidden.
+type RunnerHideModalMsg struct{}
+
+// ============================================================================
+// TICK MESSAGES
+// ============================================================================
+
+// RunnerTickMsg is sent periodically during execution for animation.
+type RunnerTickMsg struct{}
+
+// ============================================================================
+// EXECUTION MESSAGES
+// ============================================================================
+
+// RunnerExecuteNextMsg signals that the next request should be executed.
+type RunnerExecuteNextMsg struct{}
+
+// RunnerDelayCompleteMsg signals that the delay between requests is complete.
+type RunnerDelayCompleteMsg struct{}

--- a/internal/ui/runner_modal.go
+++ b/internal/ui/runner_modal.go
@@ -1,0 +1,594 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/kbrdn1/LazyCurl/internal/api"
+	"github.com/kbrdn1/LazyCurl/pkg/styles"
+)
+
+// Loader animation frames
+var loaderFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// RunnerModal displays the collection runner progress and results.
+type RunnerModal struct {
+	visible      bool
+	session      *api.RunSession
+	requests     []*api.CollectionRequest
+	width        int
+	height       int
+	scrollOffset int
+	loaderFrame  int
+	exported     bool
+	exportPath   string
+	exportError  string
+}
+
+// NewRunnerModal creates a new runner modal.
+func NewRunnerModal() *RunnerModal {
+	return &RunnerModal{
+		visible:      false,
+		session:      nil,
+		requests:     nil,
+		width:        80,
+		height:       24,
+		scrollOffset: 0,
+		loaderFrame:  0,
+	}
+}
+
+// Show makes the modal visible with the given session.
+func (m *RunnerModal) Show(session *api.RunSession, requests []*api.CollectionRequest) {
+	m.visible = true
+	m.session = session
+	m.requests = requests
+	m.scrollOffset = 0
+	m.loaderFrame = 0
+	m.exported = false
+	m.exportPath = ""
+	m.exportError = ""
+}
+
+// Hide hides the modal.
+func (m *RunnerModal) Hide() {
+	m.visible = false
+	m.session = nil
+	m.requests = nil
+	m.scrollOffset = 0
+}
+
+// IsVisible returns whether the modal is visible.
+func (m *RunnerModal) IsVisible() bool {
+	return m.visible
+}
+
+// SetSize updates the modal dimensions.
+func (m *RunnerModal) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// UpdateSession updates the session data.
+func (m *RunnerModal) UpdateSession(session *api.RunSession) {
+	m.session = session
+}
+
+// SetExported marks the export as complete.
+func (m *RunnerModal) SetExported(path string, err error) {
+	m.exported = true
+	if err != nil {
+		m.exportError = err.Error()
+		m.exportPath = ""
+	} else {
+		m.exportPath = path
+		m.exportError = ""
+	}
+}
+
+// AdvanceLoader advances the loader animation frame.
+func (m *RunnerModal) AdvanceLoader() {
+	m.loaderFrame = (m.loaderFrame + 1) % len(loaderFrames)
+}
+
+// Update handles messages for the runner modal.
+func (m *RunnerModal) Update(msg tea.Msg) (*RunnerModal, tea.Cmd) {
+	if !m.visible || m.session == nil {
+		return m, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			if m.session.IsTerminal() {
+				// Close modal when run is finished
+				m.Hide()
+				return m, func() tea.Msg {
+					return RunnerHideModalMsg{}
+				}
+			}
+			// Cancel running execution
+			return m, func() tea.Msg {
+				return RunnerCancelMsg{}
+			}
+
+		case "e":
+			if m.session.IsTerminal() && !m.exported {
+				return m, func() tea.Msg {
+					return RunnerExportMsg{}
+				}
+			}
+
+		case "enter":
+			if m.session.IsTerminal() {
+				m.Hide()
+				return m, func() tea.Msg {
+					return RunnerHideModalMsg{}
+				}
+			}
+
+		case "j", "down":
+			m.scrollDown()
+
+		case "k", "up":
+			m.scrollUp()
+
+		case "g":
+			m.scrollOffset = 0
+
+		case "G":
+			m.scrollToBottom()
+		}
+
+	case RunnerTickMsg:
+		m.AdvanceLoader()
+	}
+
+	return m, nil
+}
+
+// scrollDown scrolls the result list down.
+func (m *RunnerModal) scrollDown() {
+	maxScroll := m.maxScrollOffset()
+	if m.scrollOffset < maxScroll {
+		m.scrollOffset++
+	}
+}
+
+// scrollUp scrolls the result list up.
+func (m *RunnerModal) scrollUp() {
+	if m.scrollOffset > 0 {
+		m.scrollOffset--
+	}
+}
+
+// scrollToBottom scrolls to the bottom of the list.
+func (m *RunnerModal) scrollToBottom() {
+	m.scrollOffset = m.maxScrollOffset()
+}
+
+// maxScrollOffset returns the maximum scroll offset.
+func (m *RunnerModal) maxScrollOffset() int {
+	if m.session == nil {
+		return 0
+	}
+	visibleRows := m.visibleResultRows()
+	total := len(m.session.Results)
+	if total <= visibleRows {
+		return 0
+	}
+	return total - visibleRows
+}
+
+// visibleResultRows returns the number of result rows that can be displayed.
+func (m *RunnerModal) visibleResultRows() int {
+	// Modal height minus header, progress bar, summary, footer, borders
+	available := m.height - 16
+	if available < 3 {
+		return 3
+	}
+	return available
+}
+
+// View renders the runner modal.
+func (m *RunnerModal) View() string {
+	if !m.visible || m.session == nil {
+		return ""
+	}
+
+	// Calculate modal dimensions
+	modalWidth := min(90, m.width-6)
+	modalHeight := min(m.height-4, 30)
+
+	// Build content
+	var content strings.Builder
+
+	// Header
+	content.WriteString(m.renderHeader(modalWidth))
+	content.WriteString("\n\n")
+
+	// Progress or status
+	content.WriteString(m.renderProgress(modalWidth))
+	content.WriteString("\n\n")
+
+	// Summary stats
+	content.WriteString(m.renderSummary(modalWidth))
+	content.WriteString("\n\n")
+
+	// Results list
+	content.WriteString(m.renderResults(modalWidth))
+
+	// Export status
+	if m.exported {
+		content.WriteString("\n")
+		content.WriteString(m.renderExportStatus())
+	}
+
+	// Footer
+	content.WriteString("\n\n")
+	content.WriteString(m.renderFooter())
+
+	// Modal container style
+	modalStyle := lipgloss.NewStyle().
+		Width(modalWidth).
+		Height(modalHeight).
+		Padding(1, 2).
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(styles.Lavender).
+		Background(styles.Base)
+
+	modalContent := modalStyle.Render(content.String())
+
+	// Center the modal
+	return lipgloss.Place(
+		m.width,
+		m.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		modalContent,
+	)
+}
+
+// renderHeader renders the modal header.
+func (m *RunnerModal) renderHeader(width int) string {
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(styles.Lavender)
+
+	collectionStyle := lipgloss.NewStyle().
+		Foreground(styles.Text)
+
+	title := titleStyle.Render("▶ Collection Runner")
+
+	collectionName := m.session.Collection
+	if len(m.session.FolderPath) > 0 {
+		collectionName = strings.Join(m.session.FolderPath, " / ")
+	}
+
+	return title + " " + collectionStyle.Render(collectionName)
+}
+
+// renderProgress renders the progress bar or final status.
+func (m *RunnerModal) renderProgress(width int) string {
+	if m.session.IsTerminal() {
+		return m.renderFinalStatus()
+	}
+
+	// Animated loader
+	loader := loaderFrames[m.loaderFrame]
+
+	// Progress text
+	progress := m.session.Progress()
+
+	progressStyle := lipgloss.NewStyle().
+		Foreground(styles.Blue)
+
+	loaderStyle := lipgloss.NewStyle().
+		Foreground(styles.Lavender)
+
+	// Progress bar
+	barWidth := width - 20
+	if barWidth < 10 {
+		barWidth = 10
+	}
+
+	percent := float64(m.session.CurrentIndex) / float64(m.session.TotalRequests)
+	filled := int(float64(barWidth) * percent)
+	empty := barWidth - filled
+
+	barStyle := lipgloss.NewStyle().Foreground(styles.Green)
+	emptyStyle := lipgloss.NewStyle().Foreground(styles.Surface1)
+
+	bar := barStyle.Render(strings.Repeat("█", filled)) +
+		emptyStyle.Render(strings.Repeat("░", empty))
+
+	return fmt.Sprintf("%s %s [%s]",
+		loaderStyle.Render(loader),
+		bar,
+		progressStyle.Render(progress))
+}
+
+// renderFinalStatus renders the final run status.
+func (m *RunnerModal) renderFinalStatus() string {
+	var icon string
+	var statusStyle lipgloss.Style
+	var statusText string
+
+	switch m.session.Status {
+	case api.RunStatusCompleted:
+		icon = "✓"
+		statusStyle = lipgloss.NewStyle().Bold(true).Foreground(styles.Green)
+		statusText = "Completed"
+	case api.RunStatusCancelled:
+		icon = "○"
+		statusStyle = lipgloss.NewStyle().Bold(true).Foreground(styles.Yellow)
+		statusText = "Canceled"
+	case api.RunStatusStopped:
+		icon = "✗"
+		statusStyle = lipgloss.NewStyle().Bold(true).Foreground(styles.Red)
+		statusText = "Stopped (failure)"
+	default:
+		icon = "?"
+		statusStyle = lipgloss.NewStyle().Foreground(styles.Subtext0)
+		statusText = string(m.session.Status)
+	}
+
+	duration := m.session.EndTime.Sub(m.session.StartTime).Round(time.Millisecond)
+
+	return fmt.Sprintf("%s %s in %s",
+		statusStyle.Render(icon),
+		statusStyle.Render(statusText),
+		lipgloss.NewStyle().Foreground(styles.Subtext0).Render(duration.String()))
+}
+
+// renderSummary renders the summary statistics.
+func (m *RunnerModal) renderSummary(width int) string {
+	passedStyle := lipgloss.NewStyle().Foreground(styles.Green)
+	failedStyle := lipgloss.NewStyle().Foreground(styles.Red)
+	errorStyle := lipgloss.NewStyle().Foreground(styles.Peach)
+	skippedStyle := lipgloss.NewStyle().Foreground(styles.Subtext0)
+	labelStyle := lipgloss.NewStyle().Foreground(styles.Subtext1)
+
+	var passed, failed, errors, skipped int
+	var totalAssertions, passedAssertions, failedAssertions int
+
+	for _, r := range m.session.Results {
+		switch r.Status {
+		case api.ResultStatusPassed:
+			passed++
+			p, f := r.AssertionCount()
+			passedAssertions += p
+			failedAssertions += f
+			totalAssertions += p + f
+		case api.ResultStatusFailed:
+			failed++
+			p, f := r.AssertionCount()
+			passedAssertions += p
+			failedAssertions += f
+			totalAssertions += p + f
+		case api.ResultStatusError:
+			errors++
+		case api.ResultStatusSkipped:
+			skipped++
+		}
+	}
+
+	// Requests summary
+	requestsSummary := fmt.Sprintf("%s %s  %s %s  %s %s  %s %s",
+		passedStyle.Render(fmt.Sprintf("%d", passed)),
+		labelStyle.Render("passed"),
+		failedStyle.Render(fmt.Sprintf("%d", failed)),
+		labelStyle.Render("failed"),
+		errorStyle.Render(fmt.Sprintf("%d", errors)),
+		labelStyle.Render("errors"),
+		skippedStyle.Render(fmt.Sprintf("%d", skipped)),
+		labelStyle.Render("skipped"))
+
+	// Assertions summary (if any)
+	var assertionsSummary string
+	if totalAssertions > 0 {
+		assertionsSummary = fmt.Sprintf("\n%s: %s %s  %s %s",
+			labelStyle.Render("Assertions"),
+			passedStyle.Render(fmt.Sprintf("%d", passedAssertions)),
+			labelStyle.Render("passed"),
+			failedStyle.Render(fmt.Sprintf("%d", failedAssertions)),
+			labelStyle.Render("failed"))
+	}
+
+	return requestsSummary + assertionsSummary
+}
+
+// renderResults renders the list of request results.
+func (m *RunnerModal) renderResults(width int) string {
+	if len(m.session.Results) == 0 && m.session.TotalRequests > 0 {
+		// Show pending requests
+		return m.renderPendingList(width)
+	}
+
+	visibleRows := m.visibleResultRows()
+	var lines []string
+
+	// Add completed results
+	start := m.scrollOffset
+	end := min(start+visibleRows, len(m.session.Results))
+
+	for i := start; i < end; i++ {
+		lines = append(lines, m.renderResultRow(m.session.Results[i], width))
+	}
+
+	// Show current executing request if not all complete
+	if m.session.CurrentIndex < m.session.TotalRequests && len(lines) < visibleRows {
+		if m.session.CurrentIndex < len(m.requests) {
+			req := m.requests[m.session.CurrentIndex]
+			runningStyle := lipgloss.NewStyle().Foreground(styles.Blue)
+			loader := loaderFrames[m.loaderFrame]
+			lines = append(lines, fmt.Sprintf("%s %s %s",
+				runningStyle.Render(loader),
+				runningStyle.Render(string(req.Method)),
+				runningStyle.Render(req.Name)))
+		}
+	}
+
+	// Scroll indicator
+	if m.maxScrollOffset() > 0 {
+		scrollInfo := lipgloss.NewStyle().Foreground(styles.Subtext0).
+			Render(fmt.Sprintf(" [%d-%d of %d]", start+1, end, len(m.session.Results)))
+		if len(lines) > 0 {
+			lines[len(lines)-1] += scrollInfo
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderPendingList renders the list of pending requests before run starts.
+func (m *RunnerModal) renderPendingList(width int) string {
+	pendingStyle := lipgloss.NewStyle().Foreground(styles.Subtext0)
+	var lines []string
+
+	visibleRows := m.visibleResultRows()
+	end := min(visibleRows, len(m.requests))
+
+	for i := 0; i < end; i++ {
+		req := m.requests[i]
+		lines = append(lines, fmt.Sprintf("%s ○ %s %s",
+			pendingStyle.Render(""),
+			pendingStyle.Render(string(req.Method)),
+			pendingStyle.Render(req.Name)))
+	}
+
+	if len(m.requests) > visibleRows {
+		lines = append(lines, pendingStyle.Render(
+			fmt.Sprintf("  ... and %d more", len(m.requests)-visibleRows)))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderResultRow renders a single result row.
+func (m *RunnerModal) renderResultRow(r api.RequestResult, width int) string {
+	var icon string
+	var nameStyle lipgloss.Style
+
+	switch r.Status {
+	case api.ResultStatusPassed:
+		icon = "✓"
+		nameStyle = lipgloss.NewStyle().Foreground(styles.Green)
+	case api.ResultStatusFailed:
+		icon = "✗"
+		nameStyle = lipgloss.NewStyle().Foreground(styles.Red)
+	case api.ResultStatusError:
+		icon = "⚠"
+		nameStyle = lipgloss.NewStyle().Foreground(styles.Peach)
+	case api.ResultStatusSkipped:
+		icon = "○"
+		nameStyle = lipgloss.NewStyle().Foreground(styles.Subtext0)
+	case api.ResultStatusRunning:
+		icon = loaderFrames[m.loaderFrame]
+		nameStyle = lipgloss.NewStyle().Foreground(styles.Blue)
+	default:
+		icon = "○"
+		nameStyle = lipgloss.NewStyle().Foreground(styles.Subtext0)
+	}
+
+	iconStyle := nameStyle
+
+	// Build the line
+	method := r.Request.Method
+	name := r.Request.Name
+
+	// Status code if available
+	var statusInfo string
+	if r.Response != nil {
+		statusStyle := httpStatusStyle(r.Response.Status)
+		statusInfo = statusStyle.Render(fmt.Sprintf(" %d", r.Response.Status))
+		if r.Response.TimeMs > 0 {
+			statusInfo += lipgloss.NewStyle().Foreground(styles.Subtext0).
+				Render(fmt.Sprintf(" %dms", r.Response.TimeMs))
+		}
+	}
+
+	// Error info if present
+	var errorInfo string
+	if r.Error != nil {
+		errorInfo = lipgloss.NewStyle().Foreground(styles.Red).
+			Render(fmt.Sprintf(" (%s)", r.Error.Message))
+	}
+
+	// Assertion info
+	var assertionInfo string
+	if r.PostScriptResult != nil {
+		passed, failed := r.AssertionCount()
+		if passed+failed > 0 {
+			if failed > 0 {
+				assertionInfo = lipgloss.NewStyle().Foreground(styles.Red).
+					Render(fmt.Sprintf(" [%d/%d tests]", passed, passed+failed))
+			} else {
+				assertionInfo = lipgloss.NewStyle().Foreground(styles.Green).
+					Render(fmt.Sprintf(" [%d tests]", passed))
+			}
+		}
+	}
+
+	return fmt.Sprintf("%s %s %s%s%s%s",
+		iconStyle.Render(icon),
+		nameStyle.Render(method),
+		nameStyle.Render(name),
+		statusInfo,
+		errorInfo,
+		assertionInfo)
+}
+
+// renderExportStatus renders the export status message.
+func (m *RunnerModal) renderExportStatus() string {
+	if m.exportError != "" {
+		return lipgloss.NewStyle().Foreground(styles.Red).
+			Render("⚠ Export failed: " + m.exportError)
+	}
+	return lipgloss.NewStyle().Foreground(styles.Green).
+		Render("✓ Exported to: " + m.exportPath)
+}
+
+// renderFooter renders the modal footer with keybindings.
+func (m *RunnerModal) renderFooter() string {
+	helpStyle := lipgloss.NewStyle().Foreground(styles.Subtext0)
+
+	if m.session.IsTerminal() {
+		var hints []string
+		if !m.exported {
+			hints = append(hints, "e: Export")
+		}
+		hints = append(hints, "Enter/Esc: Close", "j/k: Scroll")
+		return helpStyle.Render(strings.Join(hints, " • "))
+	}
+
+	return helpStyle.Render("Esc: Cancel • j/k: Scroll")
+}
+
+// LoaderTickCmd returns a command that sends a tick after the given duration.
+func LoaderTickCmd() tea.Cmd {
+	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg {
+		return RunnerTickMsg{}
+	})
+}
+
+// httpStatusStyle returns a style for the given HTTP status code.
+func httpStatusStyle(status int) lipgloss.Style {
+	switch {
+	case status >= 200 && status < 300:
+		return lipgloss.NewStyle().Foreground(styles.Green)
+	case status >= 300 && status < 400:
+		return lipgloss.NewStyle().Foreground(styles.Blue)
+	case status >= 400 && status < 500:
+		return lipgloss.NewStyle().Foreground(styles.Peach)
+	case status >= 500:
+		return lipgloss.NewStyle().Foreground(styles.Red)
+	default:
+		return lipgloss.NewStyle().Foreground(styles.Subtext0)
+	}
+}


### PR DESCRIPTION
## Description

Add a Collection Runner feature that enables batch execution of HTTP requests from collections or folders. This feature allows users to run multiple requests sequentially with configurable delays, stop-on-failure behavior, and comprehensive reporting.

## Related Issue

Closes #44

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Test coverage improvement

## Changes Made

### Core API (`internal/api/runner.go`)
- `RunSession`: Manages execution state with session-scoped environment cloning
- `RunConfig`: Configurable parameters (delay, timeout, stop-on-failure, script timeout)
- `RequestResult`: Captures individual request results with timing and script outputs
- `RunReport`: Comprehensive summary with pass/fail/skip statistics
- `CollectFromCollection`: Depth-first request collection from folders

### UI Components (`internal/ui/`)
- `RunnerModal`: Interactive modal with animated progress bar and results list
- `runner_messages.go`: Bubble Tea messages for runner lifecycle events
- `runner_commands.go`: Execution commands with pre/post-script support

### Integration
- `Ctrl+R` keybinding to launch runner from Collections panel
- Modal overlay with keyboard controls (q/Escape to cancel, e to export)
- Session-scoped environment isolation for variable modifications

### Key Features
- ✅ Sequential request execution with progress tracking
- ✅ Pre-request and post-response script execution
- ✅ Variable substitution AFTER pre-request scripts (critical for dynamic values)
- ✅ Stop-on-failure with remaining requests marked as skipped
- ✅ JSON report export to `.lazycurl/reports/`
- ✅ Real-time progress display with animated loader

## Testing

- [x] Manual testing performed
- [x] Unit tests added/updated (26 new tests, ~72% coverage)
- [x] All existing tests pass (`make test`)
- [x] Build succeeds (`make build`)

### Test Coverage
```
ok  github.com/kbrdn1/LazyCurl/internal/api    0.216s
ok  github.com/kbrdn1/LazyCurl/internal/ui     0.020s
```

## Screenshots (if applicable)

*Runner modal shows progress bar, request list with status icons, and real-time updates*

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

### Critical Bug Fix
During multi-agent verification, a timing bug was identified and fixed: variable substitution was happening BEFORE pre-request script execution, which meant variables set by scripts weren't being substituted in the request URL. The fix reorders the execution flow:

1. Pre-request script execution
2. Apply environment changes from script
3. Apply script modifications to request
4. Variable substitution (now sees script-set variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection runner with modal UI to execute requests, show progress, and export run reports
  * Configurable run options (stop-on-failure, delays, timeouts) and pre/post-request script support
  * Keybinding (Ctrl+R) to start runs; UI exposes selected collection/folder context

* **Tests**
  * Extensive test coverage for runner lifecycle, config validation, collection traversal, reporting, and helpers

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->